### PR TITLE
qt: Improve TrafficGraphWidget functionality

### DIFF
--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -157,6 +157,12 @@ public:
     //! Get total bytes sent.
     virtual int64_t getTotalBytesSent() = 0;
 
+    //! Set total bytes recv
+    virtual void setTotalBytesRecv(uint64_t bytes) = 0;
+
+    //! Set total bytes sent
+    virtual void setTotalBytesSent(uint64_t bytes) = 0;
+
     //! Get mempool size.
     virtual size_t getMempoolSize() = 0;
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3779,6 +3779,14 @@ uint64_t CConnman::GetTotalBytesSent() const
     return nTotalBytesSent;
 }
 
+void CConnman::SetTotalBytesRecv(uint64_t bytes) { nTotalBytesRecv.store(bytes); }
+
+void CConnman::SetTotalBytesSent(uint64_t bytes)
+{
+    WAIT_LOCK(m_total_bytes_sent_mutex, lock);
+    nTotalBytesSent = bytes;
+}
+
 ServiceFlags CConnman::GetLocalServices() const
 {
     return m_local_services;

--- a/src/net.h
+++ b/src/net.h
@@ -1261,6 +1261,8 @@ public:
 
     uint64_t GetTotalBytesRecv() const;
     uint64_t GetTotalBytesSent() const EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex);
+    void SetTotalBytesRecv(uint64_t bytes);
+    void SetTotalBytesSent(uint64_t bytes);
 
     /** Get a unique deterministic randomizer. */
     CSipHasher GetDeterministicRandomizer(uint64_t id) const;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -285,6 +285,8 @@ public:
     }
     int64_t getTotalBytesRecv() override { return m_context->connman ? m_context->connman->GetTotalBytesRecv() : 0; }
     int64_t getTotalBytesSent() override { return m_context->connman ? m_context->connman->GetTotalBytesSent() : 0; }
+    void setTotalBytesRecv(uint64_t bytes) override { if (m_context->connman) m_context->connman->SetTotalBytesRecv(bytes); }
+    void setTotalBytesSent(uint64_t bytes) override { if (m_context->connman) m_context->connman->SetTotalBytesSent(bytes); }
     size_t getMempoolSize() override { return m_context->mempool ? m_context->mempool->size() : 0; }
     size_t getMempoolDynamicUsage() override { return m_context->mempool ? m_context->mempool->DynamicMemoryUsage() : 0; }
     size_t getMempoolMaxUsage() override { return m_context->mempool ? m_context->mempool->m_opts.max_size_bytes : 0; }

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -665,19 +665,28 @@
            <item>
             <widget class="QSlider" name="sldGraphRange">
              <property name="minimum">
-              <number>1</number>
+              <number>0</number>
              </property>
              <property name="maximum">
-              <number>288</number>
+              <number>2400</number>
+             </property>
+             <property name="singleStep">
+              <number>200</number>
              </property>
              <property name="pageStep">
-              <number>12</number>
+              <number>400</number>
              </property>
              <property name="value">
-              <number>6</number>
+              <number>0</number>
              </property>
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="tickPosition">
+              <enum>QSlider::TicksBelow</enum>
+             </property>
+             <property name="tickInterval">
+              <number>200</number>
              </property>
             </widget>
            </item>
@@ -691,16 +700,6 @@
              </property>
              <property name="alignment">
               <set>Qt::AlignCenter</set>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="btnClearTrafficGraph">
-             <property name="text">
-              <string>&amp;Reset</string>
-             </property>
-             <property name="autoDefault">
-              <bool>false</bool>
              </property>
             </widget>
            </item>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -833,6 +833,40 @@ QString formatBytes(uint64_t bytes)
     return QObject::tr("%1 GB").arg(bytes / 1'000'000'000);
 }
 
+QString formatBytesps(float val)
+{
+    if (val < 10)
+        //: "Bytes per second"
+        return QObject::tr("%1 B/s").arg(0.01 * int(val * 100 + 0.5));
+    if (val < 100)
+        //: "Bytes per second"
+        return QObject::tr("%1 B/s").arg(0.1 * int(val * 10 + 0.5));
+    if (val < 1'000)
+        //: "Bytes per second"
+        return QObject::tr("%1 B/s").arg(int(val + 0.5));
+    if (val < 10'000)
+        //: "Kilobytes per second"
+        return QObject::tr("%1 kB/s").arg(0.01 * int(val / 10 + 0.5));
+    if (val < 100'000)
+        //: "Kilobytes per second"
+        return QObject::tr("%1 kB/s").arg(0.1 * int(val / 100 + 0.5));
+    if (val < 1'000'000)
+        //: "Kilobytes per second"
+        return QObject::tr("%1 kB/s").arg(int(val / 1'000 + 0.5));
+    if (val < 10'000'000)
+        //: "Megabytes per second"
+        return QObject::tr("%1 MB/s").arg(0.01 * int(val / 10'000 + 0.5));
+    if (val < 100'000'000)
+        //: "Megabytes per second"
+        return QObject::tr("%1 MB/s").arg(0.1 * int(val / 100'000 + 0.5));
+    if (val < 10'000'000'000)
+        //: "Megabytes per second"
+        return QObject::tr("%1 MB/s").arg(long(val / 1'000'000 + 0.5));
+
+    //: "Gigabytes per second"
+    return QObject::tr("%1 GB/s").arg(long(val / 1'000'000'000 + 0.5));
+}
+
 qreal calculateIdealFontSize(int width, const QString& text, QFont font, qreal minPointSize, qreal font_size) {
     while(font_size >= minPointSize) {
         font.setPointSizeF(font_size);

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -246,6 +246,7 @@ namespace GUIUtil
     QString formatNiceTimeOffset(qint64 secs);
 
     QString formatBytes(uint64_t bytes);
+    QString formatBytesps(float bytes);
 
     qreal calculateIdealFontSize(int width, const QString& text, QFont font, qreal minPointSize = 4, qreal startPointSize = 14);
 

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -90,6 +90,8 @@ private Q_SLOTS:
     void on_openDebugLogfileButton_clicked();
     /** change the time range of the network traffic graph */
     void on_sldGraphRange_valueChanged(int value);
+    void on_sldGraphRange_sliderReleased();
+    void on_sldGraphRange_sliderPressed();
     /** update traffic statistics */
     void updateTrafficStats(quint64 totalBytesIn, quint64 totalBytesOut);
     void resizeEvent(QResizeEvent *event) override;
@@ -146,7 +148,7 @@ private:
     } const ts;
 
     void startExecutor();
-    void setTrafficGraphRange(int mins);
+    void setTrafficGraphRange(unsigned int value);
 
     enum ColumnWidths
     {
@@ -177,6 +179,8 @@ private:
     bool m_is_executing{false};
     QByteArray m_peer_widget_header_state;
     QByteArray m_banlist_widget_header_state;
+    bool slider_in_use{false};
+    int set_slider_value{0};
 
     /** Update UI with latest network info from model. */
     void updateNetworkState();

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -5,12 +5,14 @@
 #include <interfaces/node.h>
 #include <qt/trafficgraphwidget.h>
 #include <qt/clientmodel.h>
+#include <qt/guiutil.h>
 
 #include <QPainter>
 #include <QPainterPath>
 #include <QColor>
 #include <QTimer>
 
+#include <QToolTip>
 #include <chrono>
 #include <cmath>
 
@@ -20,152 +22,603 @@
 #define YMARGIN                 10
 
 TrafficGraphWidget::TrafficGraphWidget(QWidget* parent)
-    : QWidget(parent),
-      vSamplesIn(),
-      vSamplesOut()
+    : QWidget(parent)
 {
-    timer = new QTimer(this);
-    connect(timer, &QTimer::timeout, this, &TrafficGraphWidget::updateRates);
+    m_timer = new QTimer(this);
+    connect(m_timer, &QTimer::timeout, this, &TrafficGraphWidget::updateStuff);
+    m_timer->setInterval(75);
+    m_timer->start();
+    setMouseTracking(true);
+    setFocusPolicy(Qt::StrongFocus); // Make widget focusable to respond to keyboard events
 }
 
-void TrafficGraphWidget::setClientModel(ClientModel *model)
-{
-    clientModel = model;
+void TrafficGraphWidget::setClientModel(ClientModel *model) {
     if(model) {
-        nLastBytesIn = model->node().getTotalBytesRecv();
-        nLastBytesOut = model->node().getTotalBytesSent();
-    }
-}
+        m_client_model = model;
+        if (m_samples_in[0].empty() && m_samples_out[0].empty()) {
+            // Load saved traffic data if available and the arrays are empty
+            loadData();
 
-std::chrono::minutes TrafficGraphWidget::getGraphRange() const { return m_range; }
+            // Restore the saved total bytes counts to the node if they exist
+            if (m_total_bytes_recv > 0 || m_total_bytes_sent > 0) {
+                model->node().setTotalBytesRecv(m_total_bytes_recv);
+                model->node().setTotalBytesSent(m_total_bytes_sent);
+            }
 
-void TrafficGraphWidget::paintPath(QPainterPath &path, QQueue<float> &samples)
-{
-    int sampleCount = samples.size();
-    if(sampleCount > 0) {
-        int h = height() - YMARGIN * 2, w = width() - XMARGIN * 2;
-        int x = XMARGIN + w;
-        path.moveTo(x, YMARGIN + h);
-        for(int i = 0; i < sampleCount; ++i) {
-            x = XMARGIN + w - w * i / DESIRED_SAMPLES;
-            int y = YMARGIN + h - (int)(h * samples.at(i) / fMax);
-            path.lineTo(x, y);
+            return;
         }
-        path.lineTo(x, YMARGIN + h);
+
+        uint64_t nTime = GetTimeMillis();
+        for (int i = 0; i < VALUES_SIZE; i++) {
+            m_last_bytes_in[i] = model->node().getTotalBytesRecv();
+            m_last_bytes_out[i] = model->node().getTotalBytesSent();
+            m_last_time[i] = std::chrono::milliseconds{nTime};
+        }
+    } else {
+        saveData();
+        m_client_model = model;
     }
 }
 
-void TrafficGraphWidget::paintEvent(QPaintEvent *)
+bool TrafficGraphWidget::GraphRangeBump() const { return m_bump_value; }
+
+unsigned int TrafficGraphWidget::getCurrentRangeIndex() const { return m_new_value; }
+
+int TrafficGraphWidget::y_value(float value) const {
+    int h = height() - YMARGIN * 2;
+    if (m_fmax <= 0.0001f || value <= std::numeric_limits<float>::epsilon()) return YMARGIN + h;
+    float result = m_toggle ? pow(value, 0.30102) / pow(m_fmax, 0.30102) : value / m_fmax;
+    if (std::isnan(result) || std::isinf(result)) return YMARGIN + h;
+    return YMARGIN + h - (h * 1.0 * result);
+}
+
+void TrafficGraphWidget::paintPath(QPainterPath &path, QQueue<float> &samples) {
+    int sampleCount = std::min(int(DESIRED_SAMPLES * m_range / m_values[m_value]), int(samples.size()));
+    if (sampleCount <= 0 || m_range <= 0.0001f) return;
+
+    int h = height() - YMARGIN * 2, w = width() - XMARGIN * 2, x = XMARGIN + w;
+    path.moveTo(x, YMARGIN + h);
+    for(int i = 0; i < sampleCount; ++i) {
+        float sample = samples.at(i);
+        if (std::isnan(sample) || std::isinf(sample)) continue;
+        double ratio = static_cast<double>(i) * m_values[m_value] / m_range / DESIRED_SAMPLES;
+        if (std::isnan(ratio) || std::isinf(ratio)) continue;
+        x = XMARGIN + w - static_cast<int>(w * ratio);
+        path.lineTo(x, y_value(sample));
+    }
+    path.lineTo(x, YMARGIN + h);
+}
+
+void TrafficGraphWidget::mouseMoveEvent(QMouseEvent* event)
 {
+    QWidget::mouseMoveEvent(event);
+    if (m_fmax <= 0.0f) return;
+    static int last_x = -1, last_y = -1;
+    QPointF pos = event->position();
+    QPointF globalPos = event->globalPosition();
+    int x = qRound(pos.x());
+    int y = qRound(pos.y());
+    m_x_offset = qRound(globalPos.x()) - x;
+    m_y_offset = qRound(globalPos.y()) - y;
+    if (last_x == x && last_y == y) return; // Do nothing if mouse hasn't moved
+    int h = height() - YMARGIN * 2, w = width() - XMARGIN * 2;
+    int i = (w + XMARGIN - x) * DESIRED_SAMPLES / w, closest_i = -1;
+    int sampleSize = m_time_stamp[m_value].size();
+    unsigned int smallest_distance = 50;
+    bool is_in_series = true;
+    if (sampleSize && i >= -10 && i < sampleSize + 2 && y <= h + YMARGIN + 3)
+        for (int test_i = std::max(i - 2, 0); test_i < std::min(i + 10, sampleSize); test_i++) {
+            float in_val = m_samples_in[m_value].at(test_i), out_val = m_samples_out[m_value].at(test_i);
+            int y_in = y_value(in_val), y_out = y_value(out_val);
+            unsigned int distance_in = abs(y - y_in), distance_out = abs(y - y_out);
+            unsigned int min_distance = std::min(distance_in, distance_out);
+            if (min_distance < smallest_distance) {
+                smallest_distance = min_distance;
+                closest_i = test_i;
+                is_in_series = (distance_in <= distance_out);
+            }
+        }
+    if (m_tt_point != closest_i || (m_tt_point >= 0 && closest_i >= 0 && m_tt_in_series != is_in_series)) {
+        m_tt_point = closest_i;
+        m_tt_in_series = is_in_series;
+        update(); // Calls paintEvent() to draw or delete the highlighted point
+    }
+    last_x = x; last_y = y;
+}
+
+void TrafficGraphWidget::focusSlider(Qt::FocusReason reason) {
+    // Find the slider in the parent hierarchy and give it focus
+    QWidget* parent = parentWidget();
+    while (parent) {
+        QSlider* slider = parent->findChild<QSlider*>("sldGraphRange");
+        if (slider) {
+            slider->setFocus(reason);
+            break;
+        }
+        parent = parent->parentWidget();
+    }
+}
+
+void TrafficGraphWidget::mousePressEvent(QMouseEvent *event) {
+    focusSlider(Qt::MouseFocusReason);
+    QWidget::mousePressEvent(event);
+    m_toggle = !m_toggle;
+    update();
+}
+
+void TrafficGraphWidget::mouseReleaseEvent(QMouseEvent *event) {
+    QWidget::mouseReleaseEvent(event);
+    focusSlider(Qt::MouseFocusReason);
+}
+
+void TrafficGraphWidget::focusInEvent(QFocusEvent *event) {
+    QWidget::focusInEvent(event);
+    focusSlider(Qt::OtherFocusReason);
+}
+
+void TrafficGraphWidget::drawTooltipPoint(QPainter& painter) {
+    int w = width() - XMARGIN * 2;
+    double ratio = static_cast<double>(m_tt_point) * m_values[m_value] / m_range / DESIRED_SAMPLES;
+    int x = XMARGIN + w - static_cast<int>(w * ratio);
+    if (m_tt_point >= m_samples_in[m_value].size() || m_tt_point >= m_samples_out[m_value].size()) {
+        QToolTip::hideText();
+        return;
+    }
+    float inSample = m_samples_in[m_value].at(m_tt_point);
+    float outSample = m_samples_out[m_value].at(m_tt_point);
+    float selectedSample = m_tt_in_series ? inSample : outSample;
+    int y = y_value(selectedSample);
+    painter.setPen(Qt::yellow);
+    painter.drawEllipse(QPointF(x, y), 3, 3);
+    QString strTime;
+    std::chrono::milliseconds sampleTime{0};
+    if (m_tt_point + 1 < m_time_stamp[m_value].size()) sampleTime = m_time_stamp[m_value].at(m_tt_point + 1);
+    else {
+        strTime = "to ";
+        sampleTime = m_time_stamp[m_value].at(m_tt_point);
+    }
+    int age = GetTime() - sampleTime.count() / 1000;
+    if (age < 60*60*23)
+        strTime += QString::fromStdString(FormatISO8601Time(sampleTime.count() / 1000));
+    else
+        strTime += QString::fromStdString(FormatISO8601DateTime(sampleTime.count() / 1000));
+    int nDuration = (m_time_stamp[m_value].at(m_tt_point) - sampleTime).count();
+    if (nDuration > 0) {
+        if (nDuration > 9999)
+            strTime += " +" + GUIUtil::formatDurationStr(std::chrono::seconds{(nDuration+500)/1000});
+        else
+            strTime += " +" + GUIUtil::formatPingTime(std::chrono::microseconds{nDuration*1000});
+    }
+    QString strData = tr("In") + " " + GUIUtil::formatBytesps(m_samples_in[m_value].at(m_tt_point)*1000) + " " + tr("Out") + " " + GUIUtil::formatBytesps(m_samples_out[m_value].at(m_tt_point)*1000);
+    // Line below allows ToolTip to move faster than the default ToolTip timeout (10 seconds).
+    QToolTip::showText(QPoint(x + m_x_offset, y + m_y_offset), strTime + "\n. " + strData);
+    QToolTip::showText(QPoint(x + m_x_offset, y + m_y_offset), strTime + "\n  " + strData);
+    m_tt_time = GetTime();
+}
+
+void TrafficGraphWidget::paintEvent(QPaintEvent *) {
     QPainter painter(this);
     painter.fillRect(rect(), Qt::black);
 
-    if(fMax <= 0.0f) return;
+    if (m_fmax <= 0.0f) return;
 
     QColor axisCol(Qt::gray);
-    int h = height() - YMARGIN * 2;
     painter.setPen(axisCol);
+    int h = height() - YMARGIN * 2;
     painter.drawLine(XMARGIN, YMARGIN + h, width() - XMARGIN, YMARGIN + h);
 
     // decide what order of magnitude we are
-    int base = std::floor(std::log10(fMax));
+    int base = std::floor(std::log10(m_fmax));
     float val = std::pow(10.0f, base);
 
-    const QString units = tr("kB/s");
     const float yMarginText = 2.0;
 
-    // draw lines
-    painter.setPen(axisCol);
-    painter.drawText(XMARGIN, YMARGIN + h - h * val / fMax-yMarginText, QString("%1 %2").arg(val).arg(units));
-    for(float y = val; y < fMax; y += val) {
-        int yy = YMARGIN + h - h * y / fMax;
-        painter.drawLine(XMARGIN, yy, width() - XMARGIN, yy);
-    }
-    // if we drew 3 or fewer lines, break them up at the next lower order of magnitude
-    if(fMax / val <= 3.0f) {
-        axisCol = axisCol.darker();
+    // if we drew 10 or 3 fewer lines, break them up at the next lower order of magnitude
+    if (m_fmax / val <= (m_toggle ? 10.0f : 3.0f)) {
+        float oldval = val;
         val = pow(10.0f, base - 1);
-        painter.setPen(axisCol);
-        painter.drawText(XMARGIN, YMARGIN + h - h * val / fMax-yMarginText, QString("%1 %2").arg(val).arg(units));
+        painter.setPen(axisCol.darker());
+        painter.drawText(XMARGIN, y_value(val)-yMarginText, GUIUtil::formatBytesps(val*1000));
         int count = 1;
-        for(float y = val; y < fMax; y += val, count++) {
-            // don't overwrite lines drawn above
-            if(count % 10 == 0)
-                continue;
-            int yy = YMARGIN + h - h * y / fMax;
+        for(float y = val; y < (!m_toggle || m_fmax / val < 20 ? m_fmax : oldval); y += val, count++) {
+            if (count % 10 == 0) continue;
+            int yy = y_value(y);
             painter.drawLine(XMARGIN, yy, width() - XMARGIN, yy);
         }
+        if (m_toggle) {
+            int yy = y_value(val*0.1);
+            painter.setPen(axisCol.darker().darker());
+            painter.drawText(XMARGIN, yy-yMarginText, GUIUtil::formatBytesps(val*100));
+            painter.drawLine(XMARGIN, yy, width() - XMARGIN, yy);
+        }
+        val = oldval;
     }
+    // draw lines
+    painter.setPen(axisCol);
+    for (float y = val; y < m_fmax; y += val) {
+        int yy = y_value(y);
+        painter.drawLine(XMARGIN, yy, width() - XMARGIN, yy);
+    }
+    painter.drawText(XMARGIN, y_value(val)-yMarginText, GUIUtil::formatBytesps(val*1000));
 
     painter.setRenderHint(QPainter::Antialiasing);
-    if(!vSamplesIn.empty()) {
+    if (!m_samples_in[m_value].empty()) {
         QPainterPath p;
-        paintPath(p, vSamplesIn);
+        paintPath(p, m_samples_in[m_value]);
         painter.fillPath(p, QColor(0, 255, 0, 128));
         painter.setPen(Qt::green);
         painter.drawPath(p);
     }
-    if(!vSamplesOut.empty()) {
+    if (!m_samples_out[m_value].empty()) {
         QPainterPath p;
-        paintPath(p, vSamplesOut);
+        paintPath(p, m_samples_out[m_value]);
         painter.fillPath(p, QColor(255, 0, 0, 128));
         painter.setPen(Qt::red);
         painter.drawPath(p);
     }
+    if (m_tt_point >= 0 && m_tt_point < m_time_stamp[m_value].size() && isVisible() && !window()->isMinimized())
+        drawTooltipPoint(painter);
+    else
+        QToolTip::hideText();
 }
 
-void TrafficGraphWidget::updateRates()
+void TrafficGraphWidget::update_fMax()
 {
-    if(!clientModel) return;
-
-    quint64 bytesIn = clientModel->node().getTotalBytesRecv(),
-            bytesOut = clientModel->node().getTotalBytesSent();
-    float in_rate_kilobytes_per_sec = static_cast<float>(bytesIn - nLastBytesIn) / timer->interval();
-    float out_rate_kilobytes_per_sec = static_cast<float>(bytesOut - nLastBytesOut) / timer->interval();
-    vSamplesIn.push_front(in_rate_kilobytes_per_sec);
-    vSamplesOut.push_front(out_rate_kilobytes_per_sec);
-    nLastBytesIn = bytesIn;
-    nLastBytesOut = bytesOut;
-
-    while(vSamplesIn.size() > DESIRED_SAMPLES) {
-        vSamplesIn.pop_back();
-    }
-    while(vSamplesOut.size() > DESIRED_SAMPLES) {
-        vSamplesOut.pop_back();
-    }
-
     float tmax = 0.0f;
-    for (const float f : vSamplesIn) {
-        if(f > tmax) tmax = f;
-    }
-    for (const float f : vSamplesOut) {
-        if(f > tmax) tmax = f;
-    }
-    fMax = tmax;
-    update();
+    for (const float f : m_samples_in[m_new_value]) if (f > tmax) tmax = f;
+    for (const float f : m_samples_out[m_new_value]) if (f > tmax) tmax = f;
+    m_new_fmax = tmax;
+    static float last_fMax = -1;
+    if (m_new_fmax != last_fMax) last_fMax = m_new_fmax;
 }
 
-void TrafficGraphWidget::setGraphRange(std::chrono::minutes new_range)
+/**
+ * Smoothly updates a value with acceleration/deceleration for animation.
+ *
+ * @param new_val The target value to approach
+ * @param current The current value that will be updated
+ * @param increment The current rate of change (velocity), updated by this function
+ * @param length The scale factor for controlling animation speed
+ * @return true if the value was updated, false otherwise
+ *
+ * This implements a simple physics-based approach to animation:
+ * - If moving too slowly, accelerate
+ * - If moving too quickly, decelerate
+ * - If close enough to target, snap to it
+ */
+bool update_num(float new_val, float &current, float &increment, int length)
 {
-    m_range = new_range;
-    const auto msecs_per_sample{std::chrono::duration_cast<std::chrono::milliseconds>(m_range) / DESIRED_SAMPLES};
-    timer->stop();
-    timer->setInterval(msecs_per_sample);
+    if (new_val <= 0 || current == new_val) return false;
 
-    clear();
+    if (abs(increment) <= abs(0.8 * current) / length) { // allow equal to as current and increment could be zero
+        if (new_val > current)
+            increment = 1.0 * (current+1) / length; // +1s are to get it started even if current is zero
+        else
+            increment = -1.0 * (current+1) / length;
+        if (abs(increment) > abs(new_val - current)) { // Only check this when creating an increment
+            increment = 0; // Nothing to do!
+            current = new_val;
+            return true;
+        }
+    } else {
+        if (((increment > 0) && (current + increment * 2 > new_val)) ||
+                ((increment < 0) && (current + increment * 2 < new_val))) {
+            increment = increment / 2; // Keep the momentum going even if new_val is elsewhere.
+        } else {
+            if (((increment > 0) && (current + increment * 8 < new_val)) ||
+                    ((increment < 0) && (current + increment * 8 > new_val)))
+                increment = increment * 2;
+        }
+    }
+    if (abs(increment) < 0.8 * current / length) {
+        if ((increment >= 0 && new_val > current) || (increment <= 0 && new_val < current)) {
+            current = new_val;
+            increment = 0;
+        }
+    } else
+        current += increment;
+    if (current <= 0.0f) current = 0.0001f;
+
+    return true;
 }
 
-void TrafficGraphWidget::clear()
-{
-    timer->stop();
+void TrafficGraphWidget::updateStuff() {
+    if (!m_client_model) return;
+    uint64_t expected_gap = m_timer->interval(), now = GetTimeMillis();
+    static uint64_t last_jump_time = 0;
+    uint64_t m_time_offset = 0;
 
-    vSamplesOut.clear();
-    vSamplesIn.clear();
-    fMax = 0.0f;
-
-    if(clientModel) {
-        nLastBytesIn = clientModel->node().getTotalBytesRecv();
-        nLastBytesOut = clientModel->node().getTotalBytesSent();
+    if (!m_time_stamp[0].empty()) {
+        uint64_t last_time = m_time_stamp[0].front().count();
+        uint64_t actual_gap = now - last_time;
+        if (actual_gap >= 1000 + expected_gap && last_time != last_jump_time) {
+            m_time_offset = actual_gap - expected_gap;
+            last_jump_time = last_time;
+        }
     }
-    timer->start();
+
+    bool fUpdate = false;
+    for (int i = 0; i < VALUES_SIZE; i++) {
+        uint64_t msecs_per_sample = static_cast<uint64_t>(m_values[i]) * static_cast<uint64_t>(60000) / DESIRED_SAMPLES;
+        if (m_time_offset) {
+            m_offset[i] += m_time_offset;
+            if (m_offset[i] > now - m_last_time[i].count()) m_offset[i] = now - m_last_time[i].count();
+        }
+        if (now > (m_last_time[i].count() + msecs_per_sample + m_offset[i] - expected_gap/2)) {
+            m_offset[i] = 0;
+            updateRates(i);
+            if (i == m_value) {
+                if (m_tt_point >= 0 && m_tt_point < DESIRED_SAMPLES) {
+                    m_tt_point++; // Move the selected point to the left
+                    if (m_tt_point >= DESIRED_SAMPLES) m_tt_point = -1;
+                }
+                fUpdate = true;
+            }
+            if (i == m_new_value) update_fMax();
+        }
+    }
+    m_time_offset = 0;
+
+    static float y_increment = 0, x_increment = 0;
+    if (update_num(m_new_fmax, m_fmax, y_increment, height() - YMARGIN * 2)) fUpdate = true;
+    int next_m_value = m_value;
+    if (update_num(m_values[m_new_value], m_range, x_increment, width() - XMARGIN * 2)) {
+        if (m_values[m_new_value] > m_range && m_values[m_value] < m_range)
+            next_m_value = m_value + 1;
+        else if (m_value > 0 && m_values[m_new_value] <= m_range && m_values[m_value-1] > m_range * 0.99)
+            next_m_value = m_value - 1;
+        fUpdate = true;
+    } else if (m_value != m_new_value) {
+        next_m_value = m_new_value;
+        fUpdate = true;
+    }
+
+    if (next_m_value != m_value) {
+        if (m_tt_point >= 0 && m_tt_point < m_time_stamp[m_value].size())
+            m_tt_point = findClosestPointByTimestamp(m_value, m_tt_point, next_m_value);
+        else
+            m_tt_point = -1;
+        m_value = next_m_value;
+    }
+
+    static bool last_fToggle = m_toggle;
+    if (!QToolTip::isVisible() || !isVisible() || window()->isMinimized()) {
+        if (m_tt_point >= 0) { // Remove the yellow circle if the ToolTip has gone due to mouse moving elsewhere.
+            if (last_fToggle == m_toggle) m_tt_point = -1;
+            else last_fToggle = m_toggle;
+            fUpdate = true;
+        }
+    } else if (m_tt_point >= 0 && GetTime() >= m_tt_time + 9) fUpdate = true;
+
+    if (fUpdate) update();
+}
+
+void TrafficGraphWidget::updateRates(int i) {
+    std::chrono::milliseconds now{GetTimeMillis()};
+    quint64 bytesIn = m_client_model->node().getTotalBytesRecv(),
+            bytesOut = m_client_model->node().getTotalBytesSent();
+    float in_rate_kilobytes_per_msec = 0, out_rate_kilobytes_per_msec = 0;
+    int64_t actual_gap = (now - m_last_time[i]).count();
+    if (actual_gap >= 0) {
+        in_rate_kilobytes_per_msec = static_cast<float>(bytesIn - m_last_bytes_in[i]) / actual_gap;
+        out_rate_kilobytes_per_msec = static_cast<float>(bytesOut - m_last_bytes_out[i]) / actual_gap;
+    }
+    m_samples_in[i].push_front(in_rate_kilobytes_per_msec);
+    m_samples_out[i].push_front(out_rate_kilobytes_per_msec);
+    m_time_stamp[i].push_front(now);
+    m_last_time[i] = now;
+    m_last_bytes_in[i] = bytesIn;
+    m_last_bytes_out[i] = bytesOut;
+    static int8_t fFull[VALUES_SIZE] = {};
+    if (fFull[i]<=0 && m_time_stamp[i].size()+5 > DESIRED_SAMPLES)
+        fFull[i] = m_time_stamp[i].size() - DESIRED_SAMPLES - 1;
+    while (m_time_stamp[i].size() > DESIRED_SAMPLES) {
+        if (m_tt_point < 0 && m_value == i && i < VALUES_SIZE - 1 && fFull[i]<0)
+            m_bump_value = true;
+        fFull[i] = 1;
+        m_samples_in[i].pop_back();
+        m_samples_out[i].pop_back();
+        m_time_stamp[i].pop_back();
+    }
+}
+
+std::chrono::minutes TrafficGraphWidget::setGraphRange(unsigned int value) {
+    // value is the array marker plus 1 (as zero is reserved for bumping up)
+    if (!value) { // bump
+        m_bump_value = false;
+        value = m_value + 1;
+    } else value--; // get the array marker
+    int old_value = m_new_value;
+    m_new_value = std::min((int)value, VALUES_SIZE - 1);
+    if (m_new_value != old_value) {
+        update_fMax();
+        update();
+    }
+    setFocus(Qt::OtherFocusReason);
+    focusSlider(Qt::OtherFocusReason);
+
+    return std::chrono::minutes{m_values[m_new_value]};
+}
+
+void TrafficGraphWidget::saveData() {
+    try {
+        fs::path pathTrafficGraph = fs::path(m_client_model->dataDir().toStdString().c_str()) / "trafficgraphdata.dat";
+        LogPrintf("TrafficGraphWidget: Saving data to %s\n", pathTrafficGraph.generic_string());
+
+        FILE* file = fsbridge::fopen(pathTrafficGraph, "wb");
+        if (!file) {
+            LogPrintf("TrafficGraphWidget: Failed to open file for writing: %s\n", pathTrafficGraph.generic_string());
+            throw std::runtime_error("Failed to open file");
+        }
+        AutoFile fileout(file);
+        if (fileout.IsNull()) throw std::runtime_error("File stream is null");
+        fileout << static_cast<int>(1); // Version 1
+
+        uint64_t totalBytesRecv = m_client_model->node().getTotalBytesRecv();
+        uint64_t totalBytesSent = m_client_model->node().getTotalBytesSent();
+        fileout << VARINT(totalBytesRecv) << VARINT(totalBytesSent);
+
+        for (unsigned int i = 0; i < VALUES_SIZE; i++) {
+            // Save the size of these samples
+            fileout << VARINT(static_cast<uint32_t>(m_time_stamp[i].size()));
+
+            for (int j = 0; j < m_samples_in[i].size(); j++) {
+                float value = m_samples_in[i].at(j);
+                uint32_t uint_value;
+                memcpy(&uint_value, &value, sizeof(float)); // IEEE 754
+                fileout << uint_value;
+            }
+
+            for (int j = 0; j < m_samples_out[i].size(); j++) {
+                float value = m_samples_out[i].at(j);
+                uint32_t uint_value;
+                memcpy(&uint_value, &value, sizeof(float)); // IEEE 754
+                fileout << uint_value;
+            }
+
+            for (int j = 0; j < m_time_stamp[i].size(); j++)
+                fileout << VARINT(static_cast<uint64_t>(m_time_stamp[i].at(j).count()));
+
+            fileout << VARINT(m_offset[i]);
+        }
+
+        fileout.fclose();
+    } catch (const std::exception& e) {
+        LogPrintf("TrafficGraphWidget: Error saving data: %s (path: %s)\n",
+                 e.what(), m_client_model->dataDir().toStdString());
+    }
+}
+
+bool TrafficGraphWidget::loadDataFromBinary() {
+    try {
+        fs::path pathTrafficGraph = fs::path(m_client_model->dataDir().toStdString().c_str()) / "trafficgraphdata.dat";
+        LogPrintf("TrafficGraphWidget: Attempting to load data from %s\n", pathTrafficGraph.generic_string());
+
+        FILE* file = fsbridge::fopen(pathTrafficGraph, "rb");
+        if (!file) {
+            LogPrintf("TrafficGraphWidget: File not found or could not be opened\n");
+            return false;
+        }
+        AutoFile filein(file);
+        if (filein.IsNull()) return false;
+
+        int version;
+        filein >> version;
+        if (version < 1 || version > 3) return false;
+
+        filein >> VARINT(m_total_bytes_recv) >> VARINT(m_total_bytes_sent);
+
+        for (unsigned int i = 0; i < VALUES_SIZE; i++) {
+            unsigned int samplesSize;
+            filein >> VARINT(samplesSize);
+
+            for (unsigned int j = 0; j < samplesSize; j++) {
+                uint32_t uint_value;
+                filein >> uint_value;
+                float value;
+                memcpy(&value, &uint_value, sizeof(float));
+                m_samples_in[i].push_back(value);
+            }
+
+            for (unsigned int j = 0; j < samplesSize; j++) {
+                uint32_t uint_value;
+                filein >> uint_value;
+                float value;
+                memcpy(&value, &uint_value, sizeof(float));
+                m_samples_out[i].push_back(value);
+            }
+
+            for (unsigned int j = 0; j < samplesSize; j++) {
+                uint64_t timeMs;
+                filein >> VARINT(timeMs);
+                m_time_stamp[i].push_back(std::chrono::milliseconds{static_cast<int64_t>(timeMs)});
+            }
+
+            filein >> VARINT(m_offset[i]);
+        }
+
+        filein.fclose();
+
+        return true;
+    } catch (const std::exception& e) {
+        LogPrintf("TrafficGraphWidget: Error loading data: %s\n", e.what());
+        return false;
+    }
+}
+
+bool TrafficGraphWidget::loadData() {
+    bool success = loadDataFromBinary();
+
+    if (!success) return false;
+
+    // If we successfully loaded data, determine the correct band to use
+    int firstNonFullBand = VALUES_SIZE - 1;
+
+    for (int i = 0; i < VALUES_SIZE; i++)
+        if (m_time_stamp[i].size() < DESIRED_SAMPLES) {
+            firstNonFullBand = i;
+            break;
+        }
+
+    if (firstNonFullBand) { // not the first band
+        m_value = firstNonFullBand - 1; // Minus one as we're bumping it
+        m_bump_value = true;
+    }
+
+    return true;
+}
+
+int TrafficGraphWidget::findClosestPointByTimestamp(int sourceRange, int sourcePoint, int targetRange) const {
+    if (sourcePoint < 0 || sourcePoint >= m_time_stamp[sourceRange].size() ||
+        m_time_stamp[targetRange].empty()) {
+        return -1;
+    }
+
+    bool isPeak = false, isDip = false;
+    float sourceValue = m_tt_in_series ? m_samples_in[sourceRange].at(sourcePoint) : m_samples_out[sourceRange].at(sourcePoint);
+
+    if (sourcePoint > 0 && sourcePoint < m_time_stamp[sourceRange].size() - 1) {
+        float prevValue = m_tt_in_series ? m_samples_in[sourceRange].at(sourcePoint - 1) : m_samples_out[sourceRange].at(sourcePoint - 1);
+        float nextValue = m_tt_in_series ? m_samples_in[sourceRange].at(sourcePoint + 1) : m_samples_out[sourceRange].at(sourcePoint + 1);
+
+        isPeak = sourceValue > prevValue && sourceValue > nextValue;
+        isDip = sourceValue < prevValue && sourceValue < nextValue;
+    }
+
+    std::chrono::milliseconds sourceTimestamp = m_time_stamp[sourceRange].at(sourcePoint);
+    int closestPoint = -1;
+    std::chrono::milliseconds::rep minDifference = std::numeric_limits<std::chrono::milliseconds::rep>::max();
+
+    for (int i = 0; i < m_time_stamp[targetRange].size(); ++i) {
+        auto diff = std::abs(m_time_stamp[targetRange].at(i).count() - sourceTimestamp.count());
+        if (diff < minDifference) {
+            minDifference = diff;
+            closestPoint = i;
+        }
+    }
+
+    if (closestPoint >= 0 && (isPeak || isDip)) {
+        float closestValue = m_tt_in_series ? m_samples_in[targetRange].at(closestPoint) : m_samples_out[targetRange].at(closestPoint);
+        int bestPoint = closestPoint; float bestValue = closestValue;
+        uint64_t avgSampleInterval = (m_values[targetRange] * 60 * 1000) / DESIRED_SAMPLES;
+        uint64_t timeWindow = avgSampleInterval * 3;
+
+        for (int i = 0; i < m_time_stamp[targetRange].size(); ++i) {
+            uint64_t timeDiff = static_cast<uint64_t>(std::abs(m_time_stamp[targetRange].at(i).count() - sourceTimestamp.count()));
+            if (timeDiff <= timeWindow) {
+                float currentValue = m_tt_in_series ? m_samples_in[targetRange].at(i) : m_samples_out[targetRange].at(i);
+
+                if (isPeak && currentValue > bestValue) {
+                    bestPoint = i;
+                    bestValue = currentValue;
+                } else if (isDip && currentValue < bestValue) {
+                    bestPoint = i;
+                    bestValue = currentValue;
+                }
+            }
+        }
+        closestPoint = bestPoint;
+    }
+
+    return closestPoint;
 }

--- a/src/qt/trafficgraphwidget.h
+++ b/src/qt/trafficgraphwidget.h
@@ -7,6 +7,8 @@
 
 #include <QWidget>
 #include <QQueue>
+#include <QFile>
+#include <QKeyEvent>
 
 #include <chrono>
 
@@ -17,34 +19,66 @@ class QPaintEvent;
 class QTimer;
 QT_END_NAMESPACE
 
-class TrafficGraphWidget : public QWidget
-{
+#define VALUES_SIZE 13
+
+class TrafficGraphWidget : public QWidget {
     Q_OBJECT
 
 public:
     explicit TrafficGraphWidget(QWidget *parent = nullptr);
     void setClientModel(ClientModel *model);
-    std::chrono::minutes getGraphRange() const;
+    bool GraphRangeBump() const;
+    void exportData();
+    unsigned int getCurrentRangeIndex() const;
 
 protected:
     void paintEvent(QPaintEvent *) override;
+    int y_value(float value) const;
+    void mouseMoveEvent(QMouseEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void focusInEvent(QFocusEvent *event) override;
+    int findClosestPoint(int x, int y, int rangeIndex) const;
+    int findClosestPointByTimestamp(int sourceRange, int sourcePoint, int targetRange) const;
 
 public Q_SLOTS:
-    void updateRates();
-    void setGraphRange(std::chrono::minutes new_range);
-    void clear();
+    void updateStuff();
+    std::chrono::minutes setGraphRange(unsigned int value);
 
 private:
+    void saveData();
+    bool loadDataFromBinary();
+    bool loadData();
+    void update_fMax();
     void paintPath(QPainterPath &path, QQueue<float> &samples);
+    void updateRates(int value);
+    void focusSlider(Qt::FocusReason reason);
+    void drawTooltipPoint(QPainter& painter);
 
-    QTimer* timer{nullptr};
-    float fMax{0.0f};
-    std::chrono::minutes m_range{0};
-    QQueue<float> vSamplesIn;
-    QQueue<float> vSamplesOut;
-    quint64 nLastBytesIn{0};
-    quint64 nLastBytesOut{0};
-    ClientModel* clientModel{nullptr};
+    QTimer *m_timer{nullptr};
+    float m_fmax{0};
+    float m_new_fmax{0};
+    float m_range{0};
+    int m_value{0};
+    int m_new_value{0};
+    bool m_bump_value{false};
+    bool m_toggle{true};
+    int m_tt_point{-1};
+    bool m_tt_in_series{true}; // true = in series, false = out series
+    int m_x_offset{0};
+    int m_y_offset{0};
+    int64_t m_tt_time{0};
+    QQueue<float> m_samples_in[VALUES_SIZE] = {};
+    QQueue<float> m_samples_out[VALUES_SIZE] = {};
+    QQueue<std::chrono::milliseconds> m_time_stamp[VALUES_SIZE] = {};
+    quint64 m_last_bytes_in[VALUES_SIZE] = {};
+    quint64 m_last_bytes_out[VALUES_SIZE] = {};
+    std::chrono::milliseconds m_last_time[VALUES_SIZE] = {};
+    unsigned int m_values[VALUES_SIZE] = {5, 10, 20, 45, 90, 3*60, 6*60, 12*60, 24*60, 3*24*60, 7*24*60, 14*24*60, 28*24*60};
+    ClientModel *m_client_model{nullptr};
+    uint64_t m_total_bytes_recv{0};
+    uint64_t m_total_bytes_sent{0};
+    uint64_t m_offset[VALUES_SIZE] = {};
 };
 
 #endif // BITCOIN_QT_TRAFFICGRAPHWIDGET_H

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -116,6 +116,13 @@ std::optional<int64_t> ParseISO8601DateTime(std::string_view str)
     return int64_t{TicksSinceEpoch<std::chrono::seconds>(tp)};
 }
 
+std::string FormatISO8601Time(int64_t nTime) {
+    const std::chrono::sys_seconds secs{std::chrono::seconds{nTime}};
+    const auto days{std::chrono::floor<std::chrono::days>(secs)};
+    const std::chrono::hh_mm_ss hms{secs - days};
+    return strprintf("%02i:%02i:%02iZ", hms.hours().count(), hms.minutes().count(), hms.seconds().count());
+}
+
 struct timeval MillisToTimeval(int64_t nTimeout)
 {
     struct timeval timeout;

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -75,6 +75,13 @@ void MockableSteadyClock::ClearMockTime()
 
 int64_t GetTime() { return GetTime<std::chrono::seconds>().count(); }
 
+int64_t GetTimeMillis()
+{
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now().time_since_epoch()
+    ).count();
+}
+
 std::string FormatISO8601DateTime(int64_t nTime)
 {
     const std::chrono::sys_seconds secs{std::chrono::seconds{nTime}};

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -132,6 +132,7 @@ T GetTime()
  */
 std::string FormatISO8601DateTime(int64_t nTime);
 std::string FormatISO8601Date(int64_t nTime);
+std::string FormatISO8601Time(int64_t nTime);
 std::optional<int64_t> ParseISO8601DateTime(std::string_view str);
 
 /**

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -97,6 +97,12 @@ using MillisecondsDouble = std::chrono::duration<double, std::chrono::millisecon
 int64_t GetTime();
 
 /**
+ * Convenience wrapper for getting current time in milliseconds.
+ * Internally uses std::chrono::system_clock for consistency with other time functions.
+ */
+int64_t GetTimeMillis();
+
+/**
  * DEPRECATED
  * Use SetMockTime with chrono type
  *


### PR DESCRIPTION
This PR includes several improvements to the TrafficGraphWidget:

1. Enhanced traffic graph visualization with improved scaling and tooltips
2. Added persistence for traffic data between sessions
3. Improved time handling with new utility functions
4. Added support for multiple time ranges with smooth transitions
5. Updated deprecated Qt5 mouse event methods for Qt6 compatibility

Key improvements:
- Added tooltips showing detailed traffic information when hovering over data points
- Implemented data persistence to maintain traffic history between application restarts
- Added new utility functions for time formatting and millisecond precision
- Improved graph scaling with logarithmic option for better visualization of varying traffic levels
- Updated mouse event handling to use modern Qt6 APIs
- Added support for multiple time ranges (5min to 28 days) with smooth transitions
- Improved data accuracy with better timestamp handling

This is a rebase of #559 for the latest core/master, with significant improvements to the traffic graph widget's functionality and user experience.